### PR TITLE
Fix callExpression replacement

### DIFF
--- a/__tests__/fixtures/assert/output.js
+++ b/__tests__/fixtures/assert/output.js
@@ -1,13 +1,13 @@
 module.exports = function() {
   const a = 1;
-  expect(a).toBe(1);;
+  expect(a).toBe(1);
 
   const b = {
     a: 2,
   };
   expect(b).toEqual({
     a: 2,
-  });;
+  });
 
   const c = true;
   expect(c).toBeTruthy();

--- a/__tests__/fixtures/assert/output.js
+++ b/__tests__/fixtures/assert/output.js
@@ -10,15 +10,15 @@ module.exports = function() {
   });;
 
   const c = true;
-  expect(c).toBeTruthy();;
+  expect(c).toBeTruthy();
 
   const d = 5;
-  expect(d).not.toBe(3);;
+  expect(d).not.toBe(3);
 
   expect(() => {
     throw new Error("Wrong value");
-  }).toThrow(/value/);;
+  }).toThrow(/value/);
 
   const e = 1;
-  expect(e).toBe(1);;
+  expect(e).toBe(1);
 };

--- a/transformations/assert.js
+++ b/transformations/assert.js
@@ -106,14 +106,12 @@ const getTransformedSource = (source, j, fnToTransform) => {
       const args = path.value.arguments;
       const params = getParams(fnToTransform, args, j);
 
-      const a = j.expressionStatement(
-        j.callExpression(
-          j.memberExpression(
-            j.callExpression(j.identifier("expect"), params.arguments1),
-            j.identifier(params.identifier2),
-          ),
-          params.arguments2,
+      const a = j.callExpression(
+        j.memberExpression(
+          j.callExpression(j.identifier("expect"), params.arguments1),
+          j.identifier(params.identifier2),
         ),
+        params.arguments2,
       );
       return a;
     })


### PR DESCRIPTION
Currently it's replacing with an expression statement which causes a double semicolon issue. The call expression should be replaced with another node of type "callExpression"